### PR TITLE
ci: Add workflow to test distribution builds

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -53,17 +53,17 @@ jobs:
     - name: List contents of wheel
       run: python -m zipfile --list dist/deepmem-*.whl
 
-    - name: Publish distribution 📦 to Test PyPI
-      # publish to TestPyPI on tag events
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'mihirkatare/DeepMEM'
-      uses: pypa/gh-action-pypi-publish@v1.4.2
-      with:
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
+    # - name: Publish distribution 📦 to Test PyPI
+    #   # publish to TestPyPI on tag events
+    #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'mihirkatare/DeepMEM'
+    #   uses: pypa/gh-action-pypi-publish@v1.4.2
+    #   with:
+    #     password: ${{ secrets.test_pypi_password }}
+    #     repository_url: https://test.pypi.org/legacy/
 
-    - name: Publish distribution 📦 to PyPI
-      # publish to PyPI on releases
-      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'mihirkatare/DeepMEM'
-      uses: pypa/gh-action-pypi-publish@v1.4.2
-      with:
-        password: ${{ secrets.pypi_password }}
+    # - name: Publish distribution 📦 to PyPI
+    #   # publish to PyPI on releases
+    #   if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'mihirkatare/DeepMEM'
+    #   uses: pypa/gh-action-pypi-publish@v1.4.2
+    #   with:
+    #     password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Add GHA based workflow to test building a release sdist and wheel

```
* Test building sdists and wheels for the deepmem library to ensure they are valid for upload to TestPyPI and PyPI
```